### PR TITLE
feat: spec 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tb/work
+.DS_Store

--- a/tb/hdlc_shared.sv
+++ b/tb/hdlc_shared.sv
@@ -1,0 +1,27 @@
+// shared enums
+
+enum logic[2:0] {
+  Tx_SC,
+  Tx_Buff,
+  Rx_SC,
+  Rx_Buff,
+  Rx_Len
+} RegAddr;
+
+enum int {        
+  Rx_Ready,
+  Rx_Drop,
+  Rx_FrameError,
+  Rx_AbortSignal,
+  Rx_Overflow,
+  Rx_FCSen
+} RxSC_bits;
+
+enum int {        
+  Tx_Done,
+  Tx_Enable,
+  Tx_AbortFrame,
+  Tx_AbortedTrans,
+  Tx_Full
+} TxSC_bits;
+

--- a/tb/testPr_hdlc.sv
+++ b/tb/testPr_hdlc.sv
@@ -79,7 +79,7 @@ program testPr_hdlc(
   // register, and that the Rx data buffer contains correct data.
   task VerifyNormalReceive(logic [127:0][7:0] data, int Size);
     logic [7:0] ReadData;
-
+    wait(uin_hdlc.Rx_Ready);
     //Verify status register bits
     ReadAddress(Rx_SC, ReadData);
 

--- a/tb/testPr_hdlc.sv
+++ b/tb/testPr_hdlc.sv
@@ -121,7 +121,8 @@ program testPr_hdlc(
   // register, and that the Rx data buffer contains correct data.
   task VerifyOverflowReceive(logic [127:0][7:0] data, int Size);
     logic [7:0] ReadData;
-
+    
+    wait(uin_hdlc.Rx_Ready);
      // Verify status register bits
     ReadAddress(Rx_SC, ReadData);
 


### PR DESCRIPTION
This pull request introduces shared enumerations for status and control register bits, refactors existing verification tasks to use these enums, and adds new verification tasks for error and aborted frame scenarios. These changes aim to improve code readability, maintainability, and test coverage.

### Shared Enums for Status and Control Registers:
* [`tb/hdlc_shared.sv`](diffhunk://#diff-26994bb2e40c2e9d33e869adc288106bfa8a359c482f2317f2c023f0295dd574R1-R27): Added shared enums `RegAddr`, `RxSC_bits`, and `TxSC_bits` to define symbolic names for register addresses and status/control bits, replacing hardcoded indices.

### Refactoring of Verification Tasks:
* [`tb/testPr_hdlc.sv`](diffhunk://#diff-529d887a1e0640ae8282818639fdb58ddcced8c78d9119cdc9743dd9f55f6d60R37-R112): Updated `VerifyAbortReceive` and `VerifyNormalReceive` tasks to use the shared enums for accessing status/control bits, improving readability and reducing potential errors.

### New Verification Tasks:
* [`tb/testPr_hdlc.sv`](diffhunk://#diff-529d887a1e0640ae8282818639fdb58ddcced8c78d9119cdc9743dd9f55f6d60R145-R222): Added `VerifyErrorReceive` task to validate that all flags are correctly set and the Rx buffer is empty after an error.
* [`tb/testPr_hdlc.sv`](diffhunk://#diff-529d887a1e0640ae8282818639fdb58ddcced8c78d9119cdc9743dd9f55f6d60R145-R222): Added `VerifyAbortedFrame` task to ensure proper flag states and an empty Rx buffer after an aborted frame.