### PR TITLE
Spec 8 - Check that abort flag generates abort signal

### DIFF
--- a/tb/assertions_hdlc.sv
+++ b/tb/assertions_hdlc.sv
@@ -31,6 +31,15 @@ module assertions_hdlc (
     ErrCntAssertions  =  0;
   end
 
+  /// Sequence utilities:
+  
+  // TODO: REMEMBER TO LINK THIS UP TO TX ALSO!
+  sequence abort_flag_sequence(serial_line); 
+    // Pattern: 1111 1110
+    // Note that least significant bit is received first
+    !serial_line ##1 serial_line[*7];
+  endsequence
+
   /*******************************************
    *  Verify correct Rx_FlagDetect behavior  *
    *******************************************/
@@ -69,4 +78,14 @@ module assertions_hdlc (
     ErrCntAssertions++; 
   end
 
+  // Verify correct behaviour when receiving an abort pattern (Spec8, Rx)
+  property RX_AbortDetect;
+    @(posedge Clk) disable iff (!Rx_ValidFrame) (abort_flag_sequence(Rx)) |-> Rx_AbortDetect;
+  endproperty
+
+  Rx_AbortDetect_Assert : assert property (RX_AbortDetect) begin
+    $display("PASS: Abort flag successfully generated abort signal (RX)");
+  end else begin
+    $error("FAIL: Abort flag did not generate abort signal (RX)")
+  end
 endmodule

--- a/tb/assertions_hdlc.sv
+++ b/tb/assertions_hdlc.sv
@@ -34,10 +34,9 @@ module assertions_hdlc (
   /// Sequence utilities:
   
   // TODO: REMEMBER TO LINK THIS UP TO TX ALSO!
-  sequence abort_flag_sequence(serial_line); 
-    // Pattern: 1111 1110
+  sequence AbortFlag_sequence(serial_line); 
     // Note that least significant bit is received first
-    !serial_line ##1 serial_line[*7];
+    !serial_line ##1 serial_line[*7]; // Pattern: 1111 1110
   endsequence
 
   /*******************************************
@@ -80,7 +79,7 @@ module assertions_hdlc (
 
   // Verify correct behaviour when receiving an abort pattern (Spec8, Rx)
   property RX_AbortDetect;
-    @(posedge Clk) disable iff (!Rx_ValidFrame) (abort_flag_sequence(Rx)) |-> Rx_AbortDetect;
+    @(posedge Clk) disable iff (!Rx_ValidFrame) (AbortFlag_sequence(Rx)) |=> ##1 Rx_AbortDetect;
   endproperty
 
   Rx_AbortDetect_Assert : assert property (RX_AbortDetect) begin

--- a/tb/assertions_hdlc.sv
+++ b/tb/assertions_hdlc.sv
@@ -86,6 +86,6 @@ module assertions_hdlc (
   Rx_AbortDetect_Assert : assert property (RX_AbortDetect) begin
     $display("PASS: Abort flag successfully generated abort signal (RX)");
   end else begin
-    $error("FAIL: Abort flag did not generate abort signal (RX)")
+    $error("FAIL: Abort flag did not generate abort signal (RX)");
   end
 endmodule


### PR DESCRIPTION
This pull request introduces enhancements to the `assertions_hdlc` module in `tb/assertions_hdlc.sv` to improve the detection and handling of abort patterns in the HDLC protocol. The changes include the addition of a reusable sequence utility and a new property to verify abort pattern behavior.

### Enhancements to abort pattern handling:

* **Added `AbortFlag_sequence` utility**: Introduced a reusable sequence to detect the abort pattern (`1111 1110`) on the serial line, which can be linked to both RX and TX in the future.
* **New `RX_AbortDetect` property**: Implemented a property to verify correct behavior when the abort pattern is received, ensuring it triggers the `Rx_AbortDetect` signal. This includes an assertion with pass/fail messages for debugging.