### PR TITLE
refactor: transmit parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tb/work
 .DS_Store
+vsim.wlf

--- a/tb/hdlc_shared.sv
+++ b/tb/hdlc_shared.sv
@@ -24,3 +24,4 @@ enum int {
 } TxSC_bits;
 
 const logic [7:0] FRAME_FLAG = 8'b01111110;
+const int FLAG_AND_FCS_BYTES = 4; // 2 Flag bytes + 2 FCS bytes

--- a/tb/transcript
+++ b/tb/transcript
@@ -1,5 +1,5 @@
 # vsim -assertdebug -c -voptargs="+acc" test_hdlc bind_hdlc -do "log -r *; run -all; exit" 
-# Start time: 19:51:25 on Apr 23,2025
+# Start time: 21:42:17 on Apr 23,2025
 # ** Note: (vsim-3812) Design is being optimized...
 # ** Warning: ../rtl/TxFCS.sv(13): (vopt-13314) Defaulting port 'DataBuff' kind to 'var' rather than 'wire' due to default compile option setting of -svinputport=relaxed.
 # ** Note: (vopt-143) Recognized 1 FSM in module "TxFCS(fast)".
@@ -254,5 +254,5 @@
 # * 	Assertion Errors: 0	  *
 # *                               *
 # *********************************
-# End time: 19:51:31 on Apr 23,2025, Elapsed time: 0:00:06
+# End time: 21:42:25 on Apr 23,2025, Elapsed time: 0:00:08
 # Errors: 0, Warnings: 1


### PR DESCRIPTION
This pull request introduces a new task for parsing transmitted data in the testbench for HDLC (High-Level Data Link Control) and includes minor updates to constants and comments. The most significant changes involve replacing the `GetTransmissionReady` task with a new `ParseTransmittedData` task, which improves clarity and functionality in handling transmitted data.

### Functional Enhancements:
* Introduced the `ParseTransmittedData` task in `tb/testPr_hdlc.sv` to parse incoming transmissions, remove padding, and store data in a buffer. This replaces the older `GetTransmissionReady` task and improves handling of transmission padding.
* Updated the `Transmit` task in `tb/testPr_hdlc.sv` to use the new `ParseTransmittedData` task instead of `GetTransmissionReady`, streamlining the data parsing process during transmission.

### Code Maintenance:
* Added a constant `FLAG_AND_FCS_BYTES` in `tb/hdlc_shared.sv` to represent the combined size of flag and FCS bytes, improving code readability and maintainability.
* Improved comments in `tb/testPr_hdlc.sv` to clarify functionality, such as explaining the purpose of the overflow check and the new parsing task.

### Testbench Metadata:
* Updated timestamps in `tb/transcript` to reflect the new simulation run, with a slight increase in elapsed time. [[1]](diffhunk://#diff-c40ab6ccfaf58579646a42e4aeb3c26b91a0df67288f6fd6d1197e4cc10f1d0cL2-R2) [[2]](diffhunk://#diff-c40ab6ccfaf58579646a42e4aeb3c26b91a0df67288f6fd6d1197e4cc10f1d0cL257-R257)