### PR TITLE
feat: #9 spec 9

### DIFF
--- a/tb/assertions_hdlc.sv
+++ b/tb/assertions_hdlc.sv
@@ -111,6 +111,8 @@ module assertions_hdlc (
     $error("RX_EndOfFrame:: PASS: Failed to generate end of frame");
     ErrCntAssertions++; 
   end
+
+  
 /********************************************
   * Verify correct Tx_AbortedTrans behaviour *
   ********************************************/
@@ -120,10 +122,10 @@ property TX_AbortedTrans;
   !Tx_AbortFrame ##1 Tx_AbortFrame ##0 Tx_ValidFrame |=> ##1 Tx_AbortedTrans;
 endproperty
 
-TX_AbortedTrans_Detect : assert property (TX_AbortedTrans) begin 
-  $display("TX_AbortedTrans_Detect: PASS: Tx_AbortedTrans asserted after aborting frame during transmission");
+TX_AbortedTrans_Assert : assert property (TX_AbortedTrans) begin 
+  $display("TX_AbortedTrans_Assert: PASS: Tx_AbortedTrans asserted after aborting frame during transmission");
 end else begin
-  $error("TX_AbortedTrans_Detect:Error: Tx_AbortedTrans not assert after aborting frame during transmission");
+  $error("TX_AbortedTrans_Assert:: Error: Tx_AbortedTrans not assert after aborting frame during transmission");
   ErrCntAssertions++;
 end
 

--- a/tb/assertions_hdlc.sv
+++ b/tb/assertions_hdlc.sv
@@ -26,9 +26,9 @@ module assertions_hdlc (
   input  logic Rx_Overflow,
   input  logic Rx_WrBuff,
   input  logic Rx_EoF,
-  input  logic Tx_ValidFrame,
   input  logic Tx_AbortFrame,
-  input  logic Tx_AbortedTrans
+  input  logic Tx_AbortedTrans,
+  input  logic Tx_ValidFrame
 );
 
   initial begin
@@ -117,13 +117,13 @@ module assertions_hdlc (
 
 property TX_AbortedTrans;
   @(posedge Clk)
-  !Tx_AbortFrame ##1 Tx_AbortFrame && Tx_ValidFrame |=> Tx_AbortedTrans;
+  !Tx_AbortFrame ##1 Tx_AbortFrame ##0 Tx_ValidFrame |=> ##1 Tx_AbortedTrans;
 endproperty
 
 TX_AbortedTrans_Detect : assert property (TX_AbortedTrans) begin 
-  $display("PASS: Tx_AbortedTrans asserted after aborting frame during transmission");
+  $display("TX_AbortedTrans_Detect: PASS: Tx_AbortedTrans asserted after aborting frame during transmission");
 end else begin
-  $error("Error: Tx_AbortedTrans not assert after aborting frame during transmission");
+  $error("TX_AbortedTrans_Detect:Error: Tx_AbortedTrans not assert after aborting frame during transmission");
   ErrCntAssertions++;
 end
 

--- a/tb/assertions_hdlc.sv
+++ b/tb/assertions_hdlc.sv
@@ -25,7 +25,10 @@ module assertions_hdlc (
   input  logic Rx_AbortSignal,
   input  logic Rx_Overflow,
   input  logic Rx_WrBuff,
-  input  logic Rx_EoF
+  input  logic Rx_EoF,
+  input  logic Tx_ValidFrame,
+  input  logic Tx_AbortFrame,
+  input  logic Tx_AbortedTrans
 );
 
   initial begin
@@ -108,4 +111,20 @@ module assertions_hdlc (
     $error("RX_EndOfFrame:: PASS: Failed to generate end of frame");
     ErrCntAssertions++; 
   end
+/********************************************
+  * Verify correct Tx_AbortedTrans behaviour *
+  ********************************************/
+
+property TX_AbortedTrans;
+  @(posedge Clk)
+  !Tx_AbortFrame ##1 Tx_AbortFrame && Tx_ValidFrame |=> Tx_AbortedTrans;
+endproperty
+
+TX_AbortedTrans_Detect : assert property (TX_AbortedTrans) begin 
+  $display("PASS: Tx_AbortedTrans asserted after aborting frame during transmission");
+end else begin
+  $error("Error: Tx_AbortedTrans not assert after aborting frame during transmission");
+  ErrCntAssertions++;
+end
+
 endmodule

--- a/tb/bind_hdlc.sv
+++ b/tb/bind_hdlc.sv
@@ -18,9 +18,9 @@ module bind_hdlc ();
     .Rx_Overflow      (uin_hdlc.Rx_Overflow),
     .Rx_WrBuff        (uin_hdlc.Rx_WrBuff),
     .Rx_EoF           (uin_hdlc.Rx_EoF),
-    .Tx_ValidFrame    (uin_hdlc.Tx_ValidFrame),
     .Tx_AbortFrame    (uin_hdlc.Tx_AbortFrame),
-    .Tx_AbortedTrans  (uin_hdlc.Tx_AbortedTrans)
+    .Tx_AbortedTrans  (uin_hdlc.Tx_AbortedTrans),
+    .Tx_ValidFrame    (uin_hdlc.Tx_ValidFrame)
   );
 
 endmodule

--- a/tb/bind_hdlc.sv
+++ b/tb/bind_hdlc.sv
@@ -17,7 +17,10 @@ module bind_hdlc ();
     .Rx_AbortSignal   (uin_hdlc.Rx_AbortSignal),
     .Rx_Overflow      (uin_hdlc.Rx_Overflow),
     .Rx_WrBuff        (uin_hdlc.Rx_WrBuff),
-    .Rx_EoF           (uin_hdlc.Rx_EoF)
+    .Rx_EoF           (uin_hdlc.Rx_EoF),
+    .Tx_ValidFrame    (uin_hdlc.Tx_ValidFrame),
+    .Tx_AbortFrame    (uin_hdlc.Tx_AbortFrame),
+    .Tx_AbortedTrans  (uin_hdlc.Tx_AbortedTrans)
   );
 
 endmodule

--- a/tb/testPr_hdlc.sv
+++ b/tb/testPr_hdlc.sv
@@ -721,7 +721,6 @@ endtask
 
     if (Abort) begin
       // Send some bits, then abort
-      // Send some bits, then abort
       repeat(16) @(posedge uin_hdlc.Clk);
       WriteAddress(Tx_SC, 8'b1 << Tx_AbortFrame);
     end

--- a/tb/test_hdlc.sv
+++ b/tb/test_hdlc.sv
@@ -39,6 +39,8 @@ module test_hdlc ();
   assign uin_hdlc.ZeroDetect         = u_dut.u_RxChannel.ZeroDetect;
   assign uin_hdlc.Tx_AbortFrame      = u_dut.Tx_AbortFrame;
   assign uin_hdlc.Tx_Full            = u_dut.Tx_Full;
+  assign uin_hdlc.Tx_ValidFrame      = u_dut.Tx_ValidFrame;
+  assign uin_hdlc.Tx_AbortedTrans    = u_dut.Tx_AbortedTrans;
 
   //Clock
   always #250ns uin_hdlc.Clk = ~uin_hdlc.Clk;

--- a/tb/transcript
+++ b/tb/transcript
@@ -1,5 +1,5 @@
 # vsim -assertdebug -c -voptargs="+acc" test_hdlc bind_hdlc -do "log -r *; run -all; exit" 
-# Start time: 23:52:09 on Apr 23,2025
+# Start time: 09:04:37 on Apr 24,2025
 # ** Note: (vsim-3812) Design is being optimized...
 # ** Warning: ../rtl/TxFCS.sv(13): (vopt-13314) Defaulting port 'DataBuff' kind to 'var' rather than 'wire' due to default compile option setting of -svinputport=relaxed.
 # ** Note: (vopt-143) Recognized 1 FSM in module "TxFCS(fast)".
@@ -213,7 +213,6 @@
 #              4192750 - Starting task Transmit - Normal
 # *************************************************************
 # === Transmit - Normal (10 bytes) ===
-# Start verify transmit normal
 # PASS: startFlag transmitted
 # PASS: endFlag transmitted
 # VERIFY_TRANSMIT_NORMAL:: PASS: data transmitted correctly
@@ -230,9 +229,8 @@
 # VERIFY_TRANSMIT_NORMAL:: PASS: Tx_Done is high
 # VERIFY_TRANSMIT_NORMAL:: PASS: Tx_AbortFrame is low
 # VERIFY_TRANSMIT_NORMAL:: PASS: Tx_Full is low
-# End verify transmit normal
 # *************************************************************
-#              4324750 - Starting task Transmit - Overflow
+#              4332750 - Starting task Transmit - Overflow
 # *************************************************************
 # === Transmit - Overflow (10 bytes) ===
 # Overflowing buffer ...
@@ -240,23 +238,22 @@
 # VERIFY_OVERFLOW_TRANSMIT:: PASS: Tx_Done is low
 # VERIFY_OVERFLOW_TRANSMIT:: PASS: Tx_AbortFrame is low
 # *************************************************************
-#              5039750 - Starting task Transmit - Abort
+#              5055750 - Starting task Transmit - Abort
 # *************************************************************
 # === Transmit - Abort (42 bytes) ===
-# ** Error: VERIFY_ABORTED_TRANSMIT:: FAIL: Tx_AbortedTrans is low
-#    Time: 5902750 ns  Scope: test_hdlc.u_testPr.VerifyAbortedTransmit File: ./testPr_hdlc.sv Line: 409
+# TX_AbortedTrans_Detect: PASS: Tx_AbortedTrans asserted after aborting frame during transmission
 # *************************************************************
-#              5912750 - Finishing Test Program
+#              5916250 - Finishing Test Program
 # *************************************************************
-# ** Note: $stop    : ./testPr_hdlc.sv(448)
-#    Time: 5912750 ns  Iteration: 1  Instance: /test_hdlc/u_testPr
-# Break in Module testPr_hdlc at ./testPr_hdlc.sv line 448
-# Stopped at ./testPr_hdlc.sv line 448
+# ** Note: $stop    : ./testPr_hdlc.sv(437)
+#    Time: 5916250 ns  Iteration: 1  Instance: /test_hdlc/u_testPr
+# Break in Module testPr_hdlc at ./testPr_hdlc.sv line 437
+# Stopped at ./testPr_hdlc.sv line 437
 #  exit
 # *********************************
 # *                               *
-# * 	Assertion Errors: 1	  *
+# * 	Assertion Errors: 0	  *
 # *                               *
 # *********************************
-# End time: 23:52:14 on Apr 23,2025, Elapsed time: 0:00:05
-# Errors: 1, Warnings: 1
+# End time: 09:04:43 on Apr 24,2025, Elapsed time: 0:00:06
+# Errors: 0, Warnings: 1

--- a/tb/transcript
+++ b/tb/transcript
@@ -1,5 +1,5 @@
 # vsim -assertdebug -c -voptargs="+acc" test_hdlc bind_hdlc -do "log -r *; run -all; exit" 
-# Start time: 09:04:37 on Apr 24,2025
+# Start time: 09:10:14 on Apr 24,2025
 # ** Note: (vsim-3812) Design is being optimized...
 # ** Warning: ../rtl/TxFCS.sv(13): (vopt-13314) Defaulting port 'DataBuff' kind to 'var' rather than 'wire' due to default compile option setting of -svinputport=relaxed.
 # ** Note: (vopt-143) Recognized 1 FSM in module "TxFCS(fast)".
@@ -230,7 +230,7 @@
 # VERIFY_TRANSMIT_NORMAL:: PASS: Tx_AbortFrame is low
 # VERIFY_TRANSMIT_NORMAL:: PASS: Tx_Full is low
 # *************************************************************
-#              4333750 - Starting task Transmit - Overflow
+#              4332750 - Starting task Transmit - Overflow
 # *************************************************************
 # === Transmit - Overflow (10 bytes) ===
 # Overflowing buffer ...
@@ -241,19 +241,19 @@
 #              5055750 - Starting task Transmit - Abort
 # *************************************************************
 # === Transmit - Abort (42 bytes) ===
-# TX_AbortedTrans_Detect: PASS: Tx_AbortedTrans asserted after aborting frame during transmission
+# TX_AbortedTrans_Assert: PASS: Tx_AbortedTrans asserted after aborting frame during transmission
 # *************************************************************
 #              5916250 - Finishing Test Program
 # *************************************************************
-# ** Note: $stop    : ./testPr_hdlc.sv(437)
+# ** Note: $stop    : ./testPr_hdlc.sv(438)
 #    Time: 5916250 ns  Iteration: 1  Instance: /test_hdlc/u_testPr
-# Break in Module testPr_hdlc at ./testPr_hdlc.sv line 437
-# Stopped at ./testPr_hdlc.sv line 437
+# Break in Module testPr_hdlc at ./testPr_hdlc.sv line 438
+# Stopped at ./testPr_hdlc.sv line 438
 #  exit
 # *********************************
 # *                               *
 # * 	Assertion Errors: 0	  *
 # *                               *
 # *********************************
-# End time: 09:04:43 on Apr 24,2025, Elapsed time: 0:00:06
+# End time: 09:10:17 on Apr 24,2025, Elapsed time: 0:00:03
 # Errors: 0, Warnings: 1

--- a/tb/transcript
+++ b/tb/transcript
@@ -1,5 +1,5 @@
 # vsim -assertdebug -c -voptargs="+acc" test_hdlc bind_hdlc -do "log -r *; run -all; exit" 
-# Start time: 22:00:49 on Apr 23,2025
+# Start time: 23:52:09 on Apr 23,2025
 # ** Note: (vsim-3812) Design is being optimized...
 # ** Warning: ../rtl/TxFCS.sv(13): (vopt-13314) Defaulting port 'DataBuff' kind to 'var' rather than 'wire' due to default compile option setting of -svinputport=relaxed.
 # ** Note: (vopt-143) Recognized 1 FSM in module "TxFCS(fast)".
@@ -232,7 +232,7 @@
 # VERIFY_TRANSMIT_NORMAL:: PASS: Tx_Full is low
 # End verify transmit normal
 # *************************************************************
-#              4332750 - Starting task Transmit - Overflow
+#              4324750 - Starting task Transmit - Overflow
 # *************************************************************
 # === Transmit - Overflow (10 bytes) ===
 # Overflowing buffer ...
@@ -240,17 +240,23 @@
 # VERIFY_OVERFLOW_TRANSMIT:: PASS: Tx_Done is low
 # VERIFY_OVERFLOW_TRANSMIT:: PASS: Tx_AbortFrame is low
 # *************************************************************
-#              5055750 - Finishing Test Program
+#              5039750 - Starting task Transmit - Abort
 # *************************************************************
-# ** Note: $stop    : ./testPr_hdlc.sv(435)
-#    Time: 5055750 ns  Iteration: 2  Instance: /test_hdlc/u_testPr
-# Break in Module testPr_hdlc at ./testPr_hdlc.sv line 435
-# Stopped at ./testPr_hdlc.sv line 435
+# === Transmit - Abort (42 bytes) ===
+# ** Error: VERIFY_ABORTED_TRANSMIT:: FAIL: Tx_AbortedTrans is low
+#    Time: 5902750 ns  Scope: test_hdlc.u_testPr.VerifyAbortedTransmit File: ./testPr_hdlc.sv Line: 409
+# *************************************************************
+#              5912750 - Finishing Test Program
+# *************************************************************
+# ** Note: $stop    : ./testPr_hdlc.sv(448)
+#    Time: 5912750 ns  Iteration: 1  Instance: /test_hdlc/u_testPr
+# Break in Module testPr_hdlc at ./testPr_hdlc.sv line 448
+# Stopped at ./testPr_hdlc.sv line 448
 #  exit
 # *********************************
 # *                               *
-# * 	Assertion Errors: 0	  *
+# * 	Assertion Errors: 1	  *
 # *                               *
 # *********************************
-# End time: 22:00:54 on Apr 23,2025, Elapsed time: 0:00:05
-# Errors: 0, Warnings: 1
+# End time: 23:52:14 on Apr 23,2025, Elapsed time: 0:00:05
+# Errors: 1, Warnings: 1


### PR DESCRIPTION
This pull request introduces enhancements to the HDLC testbench to include new transmission-related signals and their corresponding assertions, updates the simulation test program to validate these changes, and improves the overall test coverage. Below are the key changes grouped by theme:

### Signal Additions and Assertions

* Added new input signals `Tx_AbortFrame`, `Tx_AbortedTrans`, and `Tx_ValidFrame` to the `assertions_hdlc` module for better monitoring of transmission behaviors (`tb/assertions_hdlc.sv`).
* Introduced a new property `TX_AbortedTrans` to verify the behavior of `Tx_AbortedTrans` when a frame is aborted during transmission. Added an assertion to detect and log the outcome (`tb/assertions_hdlc.sv`).

### Testbench Updates

* Updated the `bind_hdlc` module to bind the new signals (`Tx_AbortFrame`, `Tx_AbortedTrans`, and `Tx_ValidFrame`) to the corresponding signals in the design under test (`tb/bind_hdlc.sv`).
* Updated the `test_hdlc` module to assign the new signals (`Tx_AbortFrame`, `Tx_AbortedTrans`, and `Tx_ValidFrame`) for simulation purposes (`tb/test_hdlc.sv`).

### Simulation Enhancements

* Added a new test case in the `testPr_hdlc` program to simulate an aborted transmission scenario (`Transmit(42, 1, 0)`), ensuring the new assertions are exercised (`tb/testPr_hdlc.sv`).
* Enhanced the `Transmit` task to properly handle abort scenarios, including writing to the abort signal and verifying the transmitted data (`tb/testPr_hdlc.sv`).

### Simulation Transcript Updates

* Updated the simulation transcript to reflect the new test case for aborted transmission and its corresponding assertion results (`tb/transcript`).