### PR TITLE
feat: added spec 17 by concurrent assertion #17

### DIFF
--- a/tb/bind_hdlc.sv
+++ b/tb/bind_hdlc.sv
@@ -21,7 +21,11 @@ module bind_hdlc ();
     .Tx               (uin_hdlc.Tx),
     .Tx_AbortFrame    (uin_hdlc.Tx_AbortFrame),
     .Tx_AbortedTrans  (uin_hdlc.Tx_AbortedTrans),
-    .Tx_ValidFrame    (uin_hdlc.Tx_ValidFrame)
+    .Tx_ValidFrame    (uin_hdlc.Tx_ValidFrame),
+    .Tx_Enable        (uin_hdlc.Tx_Enable),
+    .Tx_FrameSize     (uin_hdlc.Tx_FrameSize),
+    .Tx_BufferCount   (uin_hdlc.Tx_BufferCount),
+    .Tx_Done          (uin_hdlc.Tx_Done)
   );
 
 endmodule

--- a/tb/coverage_report.txt
+++ b/tb/coverage_report.txt
@@ -239,27 +239,29 @@ Name                 File(Line)                   Failure      Pass     Vacuous 
 =================================================================================
 
 Assertion Coverage:
-    Assertions                       8         8         0   100.00%
+    Assertions                       9         9         0   100.00%
 --------------------------------------------------------------------------------------------------------------------------------
 Name                 File(Line)                   Failure      Pass     Vacuous    Disable    Attempt     Active Peak Active ATV
                                                   Count        Count    Count      Count      Count       Count  Count          
 --------------------------------------------------------------------------------------------------------------------------------
 /test_hdlc/u_assertion_bind/RX_FlagDetect_Assert
-                     ./assertions_hdlc.sv(103)          0         24      11809          0      11833          0           3 off
+                     ./assertions_hdlc.sv(107)          0         24      11809          0      11833          0           3 off
 /test_hdlc/u_assertion_bind/RX_AbortSignal_Assert
-                     ./assertions_hdlc.sv(120)          0          2       6407       5424      11833          0           1 off
+                     ./assertions_hdlc.sv(124)          0          2       6407       5424      11833          0           1 off
 /test_hdlc/u_assertion_bind/Rx_AbortDetect_Assert
-                     ./assertions_hdlc.sv(132)          0          2       6396       5435      11833          0           2 off
+                     ./assertions_hdlc.sv(136)          0          2       6396       5435      11833          0           2 off
 /test_hdlc/u_assertion_bind/Rx_EndOfFrameDetect
-                     ./assertions_hdlc.sv(146)          0         13      11820          0      11833          0           2 off
+                     ./assertions_hdlc.sv(150)          0         13      11820          0      11833          0           2 off
 /test_hdlc/u_assertion_bind/TX_AbortedTrans_Assert
-                     ./assertions_hdlc.sv(163)          0          1      11831          0      11833          1           3 off
+                     ./assertions_hdlc.sv(167)          0          1      11831          0      11833          1           3 off
+/test_hdlc/u_assertion_bind/TransmitComplete_Assert
+                     ./assertions_hdlc.sv(183)          0          2      11831          0      11833          0           1 off
 /test_hdlc/u_assertion_bind/TX_IdlePattern_Assert
-                     ./assertions_hdlc.sv(179)          0      10631       1202          0      11833          0           1 off
+                     ./assertions_hdlc.sv(199)          0      10631       1202          0      11833          0           1 off
 /test_hdlc/u_assertion_bind/TX_ZeroPadding_Assert
-                     ./assertions_hdlc.sv(194)          0         15       1127      10691      11833          0           2 off
+                     ./assertions_hdlc.sv(214)          0         15       1127      10691      11833          0           2 off
 /test_hdlc/u_assertion_bind/TX_AbortFlag_Assert
-                     ./assertions_hdlc.sv(209)          0          1      11832          0      11833          0           1 off
+                     ./assertions_hdlc.sv(229)          0          1      11832          0      11833          0           1 off
 
 COVERGROUP COVERAGE:
 ----------------------------------------------------------------------------------------------------------
@@ -482,21 +484,23 @@ Name                 File(Line)                   Failure      Pass     Vacuous 
 /test_hdlc/u_testPr/VerifyTransmitOverflow/immed__386
                      ./testPr_hdlc.sv(386)              0          1          0          0          1          0           0 off
 /test_hdlc/u_assertion_bind/RX_FlagDetect_Assert
-                     ./assertions_hdlc.sv(103)          0         24      11809          0      11833          0           3 off
+                     ./assertions_hdlc.sv(107)          0         24      11809          0      11833          0           3 off
 /test_hdlc/u_assertion_bind/RX_AbortSignal_Assert
-                     ./assertions_hdlc.sv(120)          0          2       6407       5424      11833          0           1 off
+                     ./assertions_hdlc.sv(124)          0          2       6407       5424      11833          0           1 off
 /test_hdlc/u_assertion_bind/Rx_AbortDetect_Assert
-                     ./assertions_hdlc.sv(132)          0          2       6396       5435      11833          0           2 off
+                     ./assertions_hdlc.sv(136)          0          2       6396       5435      11833          0           2 off
 /test_hdlc/u_assertion_bind/Rx_EndOfFrameDetect
-                     ./assertions_hdlc.sv(146)          0         13      11820          0      11833          0           2 off
+                     ./assertions_hdlc.sv(150)          0         13      11820          0      11833          0           2 off
 /test_hdlc/u_assertion_bind/TX_AbortedTrans_Assert
-                     ./assertions_hdlc.sv(163)          0          1      11831          0      11833          1           3 off
+                     ./assertions_hdlc.sv(167)          0          1      11831          0      11833          1           3 off
+/test_hdlc/u_assertion_bind/TransmitComplete_Assert
+                     ./assertions_hdlc.sv(183)          0          2      11831          0      11833          0           1 off
 /test_hdlc/u_assertion_bind/TX_IdlePattern_Assert
-                     ./assertions_hdlc.sv(179)          0      10631       1202          0      11833          0           1 off
+                     ./assertions_hdlc.sv(199)          0      10631       1202          0      11833          0           1 off
 /test_hdlc/u_assertion_bind/TX_ZeroPadding_Assert
-                     ./assertions_hdlc.sv(194)          0         15       1127      10691      11833          0           2 off
+                     ./assertions_hdlc.sv(214)          0         15       1127      10691      11833          0           2 off
 /test_hdlc/u_assertion_bind/TX_AbortFlag_Assert
-                     ./assertions_hdlc.sv(209)          0          1      11832          0      11833          0           1 off
+                     ./assertions_hdlc.sv(229)          0          1      11832          0      11833          0           1 off
 
 Total Coverage By Instance (filtered view): 100.00%
 

--- a/tb/in_hdlc.sv
+++ b/tb/in_hdlc.sv
@@ -31,6 +31,7 @@ interface in_hdlc ();
   logic Tx_Enable;
   logic Tx_Full;
   logic [7:0] Tx_FrameSize;
+  logic [7:0] Tx_BufferCount;
 
   // RX
   logic Rx;

--- a/tb/test_hdlc.sv
+++ b/tb/test_hdlc.sv
@@ -44,6 +44,7 @@ module test_hdlc ();
   assign uin_hdlc.Tx_AbortedTrans    = u_dut.Tx_AbortedTrans;
   assign uin_hdlc.Tx_Enable          = u_dut.Tx_Enable;
   assign uin_hdlc.Tx_FrameSize       = u_dut.Tx_FrameSize;
+  assign uin_hdlc.Tx_BufferCount     = u_dut.u_TxBuff.Count;
 
   //Clock
   always #250ns uin_hdlc.Clk = ~uin_hdlc.Clk;

--- a/tb/transcript
+++ b/tb/transcript
@@ -1,5 +1,5 @@
 # vsim -coverage -assertdebug -c -voptargs="+acc" test_hdlc bind_hdlc -do "log -r *; run -all; coverage report -file coverage_report.txt -details; exit" 
-# Start time: 11:13:56 on Apr 24,2025
+# Start time: 11:44:04 on Apr 24,2025
 # ** Note: (vsim-3812) Design is being optimized...
 # ** Warning: ../rtl/TxFCS.sv(13): (vopt-13314) Defaulting port 'DataBuff' kind to 'var' rather than 'wire' due to default compile option setting of -svinputport=relaxed.
 # ** Note: (vopt-143) Recognized 1 FSM in module "TxFCS(fast)".
@@ -228,6 +228,7 @@
 #              4192750 - Starting task Transmit - Normal
 # *************************************************************
 # === Transmit - Normal (10 bytes) ===
+# TransmitComplete_Assert: SUCCESS: Tx_Complete asserted after TX buffer emptied
 # PASS: startFlag transmitted
 # PASS: endFlag transmitted
 # VERIFY_TRANSMIT_NORMAL:: PASS: data transmitted correctly
@@ -256,6 +257,7 @@
 #              5055750 - Starting task Transmit - Abort
 # *************************************************************
 # === Transmit - Abort (42 bytes) ===
+# TransmitComplete_Assert: SUCCESS: Tx_Complete asserted after TX buffer emptied
 # TX_AbortedTrans_Assert: PASS: Tx_AbortedTrans asserted after aborting frame during transmission
 # TX_AbortFlag_Assert: PASS: Transmittet abort flag sequence
 # *************************************************************
@@ -273,5 +275,5 @@
 # * 	Assertion Errors: 0	  *
 # *                               *
 # *********************************
-# End time: 11:14:02 on Apr 24,2025, Elapsed time: 0:00:06
+# End time: 11:44:11 on Apr 24,2025, Elapsed time: 0:00:07
 # Errors: 0, Warnings: 3


### PR DESCRIPTION
This pull request introduces enhancements to the HDLC testbench by adding new signals, assertions, and coverage metrics to improve the verification of transmission behavior. The key changes include the addition of new inputs to modules, a new assertion to verify transmission completion, and updates to coverage and test reports to reflect these changes.

### Enhancements to module inputs:
* Added new inputs `Tx_Enable`, `Tx_FrameSize`, `Tx_BufferCount`, and `Tx_Done` to the `assertions_hdlc` and `bind_hdlc` modules to support additional verification logic (`tb/assertions_hdlc.sv`, `tb/bind_hdlc.sv`) [[1]](diffhunk://#diff-ae0944a7d8c992a750471cc9db3a431a47dd46b18b561c85ab284705b8f86b09L32-R36) [[2]](diffhunk://#diff-4d4bad89b349cbe2a2c6c79525ebdcd39d1eda1571ccce16b64e9433b3568c94L24-R28).
* Updated the `in_hdlc` interface to include the `Tx_BufferCount` signal (`tb/in_hdlc.sv`).
* Assigned the `Tx_BufferCount` signal in the `test_hdlc` module to connect it to the corresponding buffer count in the DUT (`tb/test_hdlc.sv`).

### New assertion for transmission completion:
* Added the `TransmitComplete` property and corresponding assertion to verify that `Tx_Done` is correctly asserted when the TX buffer is emptied (`tb/assertions_hdlc.sv`).

### Updates to coverage and test reports:
* Incremented the total number of assertions in the coverage report to include the new `TransmitComplete_Assert`. Updated line references for existing assertions due to the new additions (`tb/coverage_report.txt`) [[1]](diffhunk://#diff-1fde0d32fe337f883fd527edbcbffe8005f0728bdec094f6d6202e096d6f8710L242-R264) [[2]](diffhunk://#diff-1fde0d32fe337f883fd527edbcbffe8005f0728bdec094f6d6202e096d6f8710L485-R503).
* Updated the test transcript to log successful passes of the `TransmitComplete_Assert` during both normal and abort transmission tests (`tb/transcript`) [[1]](diffhunk://#diff-c40ab6ccfaf58579646a42e4aeb3c26b91a0df67288f6fd6d1197e4cc10f1d0cR231) [[2]](diffhunk://#diff-c40ab6ccfaf58579646a42e4aeb3c26b91a0df67288f6fd6d1197e4cc10f1d0cR260).

### Miscellaneous:
* Updated the simulation start and end times in the transcript to reflect the new test execution (`tb/transcript`) [[1]](diffhunk://#diff-c40ab6ccfaf58579646a42e4aeb3c26b91a0df67288f6fd6d1197e4cc10f1d0cL2-R2) [[2]](diffhunk://#diff-c40ab6ccfaf58579646a42e4aeb3c26b91a0df67288f6fd6d1197e4cc10f1d0cL276-R278).